### PR TITLE
Sub in mana crypt for mind stone

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This is a simple repository for my EDH decks. They will be updated as needed and
 
 ## Current roster
 
-- Mono black Golos (v1.0.0)
+- Mono black Golos (v1.1.0)

--- a/mono-black-golos.txt
+++ b/mono-black-golos.txt
@@ -25,7 +25,7 @@
 1 Ugin, the Spirit Dragon
 1 K'rrik, Son of Yawgmoth
 1 Liliana of the Dark Realms
-1 Mind Stone
+1 Mana Crypt
 1 Phyrexian Reclamation
 1 Wurmcoil Engine
 1 Crypt Ghast


### PR DESCRIPTION
## Summary
Just makes sense. Mind Stone's been in here for a while, but the Crypt is the clear winner.